### PR TITLE
Add milestones link, titles and descriptions

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -96,25 +96,29 @@
         "description":"An actual or target observation. Observations should include either a value (for financial metrics) or quantity (for other metrics). ",
         "properties":{
             "id": {
-                "title":"Identifier",
+                "title":"Observation identifier",
                 "description":"A local identifier for this specific observation. This may be an arbitrary identifier, or could be a composite of the metric identifier, and the date and other dimensions of this observation.",
                 "type":"string"
             },
             "period":{
-                "$ref": "#/definitions/Period"
+                "title": "Observation period",
+				"description": "The period to which this forecast, target or actual observation applies.",
+				"$ref": "#/definitions/Period"
             },
             "value": {
-                "$ref": "#/definitions/Value"
+                "title": "Observation value",
+				"description": "For financial metrics, the value of this forecast, target or actual observation.",
+				"$ref": "#/definitions/Value"
             },
             "quantity": {
-                "title":"Quantity",
-                "description":"The quantity of this target or observation.",
+                "title":"Observation quantity",
+                "description":"For non-financial metrics, the quantity of this forecast, target or actual observation.",
                 "type":["string","number","null"]
             },
             "unit":{
                 "type":["object","null"],
-                "title":"Unit",
-                "description":"Unit",
+                "title":"Observation unit",
+                "description":"The unit in which this observation is measured.",
                 "properties": {
                     "name": {
                         "type":["string","null"],
@@ -128,15 +132,45 @@
             },
             "dimensions":{
                 "type":"object",
-                "title":"Dimensions",
+                "title":"Observation dimensions",
                 "description":"Any number of dimensions can be recorded within this object. Dimensions names should follow the camelCase conventions of OCDS."
             },
             "notes": {
-                "title":"Notes",
+                "title":"Observation notes",
                 "description":"Any notes on this observation. This may include clarifying information.",
                 "type":["string","null"]
-            }
+            },
+			"relatedImplementationMilestone": {
+				"title": "Related implementation milestone",
+				"description": "A link to the milestone in the implementation section of OCDS to which this forecast, target or actual observation relates.",
+				"$ref": "#/definitions/milestoneReference"
+			}
         }
+    },
+    "milestoneReference": {
+      "type": "object",
+      "title": "Milestone Reference",
+      "description": "A block used to reference a milestone, including the ID and title of the milestone being referenced.",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "title": "Milestone ID",
+          "description": "The ID of the milestone being referenced, this must match the ID of a milestone described elsewhere in a release about this contracting process.",
+          "type": "string",
+          "mergeStrategy": "ocdsVersion"
+        },
+        "title": {
+          "title": "Milestone title",
+          "description": "The title of the milestone being referenced, this must match the title of a milestone described elsewhere in a release about this contracting process.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "mergeStrategy": "ocdsVersion"
+        }
+      }
     }
   }
 }

--- a/release-schema.json
+++ b/release-schema.json
@@ -63,7 +63,7 @@
     "Metric": {
       "type": "object",
       "title": "Metric",
-      "description": "Metrics are used to set out targets and results from a contracting process. During the planning and tender sections, a metric indicates the anticipated results. In award and contract sections it indicates the awarded/contracted results. In the implementation section it is used to provide updates on actually delivered results.",
+      "description": "Metrics are used to set out targets and results from a contracting process. During the planning and tender sections, a metric indicates the anticipated results. In award and contract sections it indicates the awarded/contracted results. In the implementation section it is used to provide updates on actually delivered results, also known as outputs.",
       "properties": {
         "id": {
           "title": "Identifier",


### PR DESCRIPTION
Add relatedImplementationMilestone property to observation object.

Add milestoneReference definition (this was previously introduced by the
equityTransferCaps extension which has now been removed)

Add missing titles/descriptions

Update existing titles/descriptions